### PR TITLE
2.0

### DIFF
--- a/2.0/EWN-LMF-2.0-relax_idrefs.xsd
+++ b/2.0/EWN-LMF-2.0-relax_idrefs.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='ewn-idtypes-relax_idrefs.xsd' />
+	<xsd:include schemaLocation='ewn-wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='core-2.0.xsd' />
+
+</xsd:schema>

--- a/2.0/EWN-LMF-2.0.xsd
+++ b/2.0/EWN-LMF-2.0.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='ewn-idtypes.xsd' />
+	<xsd:include schemaLocation='ewn-wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='core-2.0.xsd' />
+
+</xsd:schema>

--- a/2.0/README.md
+++ b/2.0/README.md
@@ -19,7 +19,6 @@ It is not desirable to mix **foreign references** (in the sense that they refer 
 
  The design is modular:
  
-***ili.xsd*** and ***pwn.xsd*** for all the ILI and PWN stuff in their own namespaces.
 ***(ewn-)idtypes(-relax_idrefs).xsd*** for core id types (it defines ID policy).
 ***(ewn-)wordtypes.xsd*** for word types (it defines word form policy).
 ***types.xsd*** for core data types.
@@ -30,19 +29,19 @@ It is not desirable to mix **foreign references** (in the sense that they refer 
 
 This allows for different levels of validation to be performed. 
 
-This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next.For example the data that satisfies EWN-LMF-2.0.xsd is a subset of data validated by WN-LMF-2.0.xsd (or  WN-LMF-2.0 is a superset of EWN-LMF-2.0). 
+This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next. For example the data that satisfies EWN-LMF-2.0.xsd is a subset of data validated by WN-LMF-2.0.xsd (or  WN-LMF-2.0 is a superset of EWN-LMF-2.0). 
 
 Another use is different IDREF validation depending on whether you are attempting at validating merged files or not.
 
 ####id types
 
-idtypes-2.0.xsd and ewn-idtypes-2.0.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.
+idtypes.xsd and ewn-idtypes.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.
 
 ####relaxed id types vs strict
 
 This deals with **id reference** validation.
 
-*(ewn-)idtypes-2.0.xsd* and *(ewn-)idtypes-2.0-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.
+*(ewn-)idtypes.xsd* and *(ewn-)idtypes-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.
 
 ####some resulting combinations:
 

--- a/2.0/README.md
+++ b/2.0/README.md
@@ -1,0 +1,73 @@
+#WordNet-LMF 2.0
+#===
+
+This is to equip WordNet with state-of-the-art validation schemas the way FrameNet did. This move is dictated by the following:
+
+- DTD does not provide fine-grained control the way XSD does. The most significant difference between DTDs and XML Schema is the capability to create and use **datatypes**. XSD schemas define datatypes for elements and attributes while DTD doesn't support them. This allows for control on what sort of data (ids, content) is expected. Leveraging datatypes gets errors to bubble up instantly that would otherwise go unnoticed.
+
+- It is desirable to distinguish foreign references from internal ones (more below).
+
+- Incidentally the reference to  Dublin Core schema is erroneous (as mentioned [here](https://github.com/globalwordnet/schemas/issues/5) ) in that the definition of elements is mistakenly applied to attributes. Any real validation against the Dublin Core definitions would fail. Besides, Dublin Core seems superimposed and unnatural and it is doubtful it is of real use here.
+
+####name spaces
+
+References to ILI and PWN have been transferred to their own namespace (ili: and pwn: respectively) as do the meta annotations (meta:). 
+
+It is not desirable to mix **foreign references** (in the sense that they refer to something outside the database, the PWN sensekey is a case in point) with **internal references**. Different namespaces reflect this.
+
+####modules
+
+ The design is modular:
+ 
+***ili.xsd*** and ***pwn.xsd*** for all the ILI and PWN stuff in their own namespaces.
+***(ewn-)idtypes(-relax_idrefs).xsd*** for core id types (it defines ID policy).
+***(ewn-)wordtypes.xsd*** for word types (it defines word form policy).
+***types.xsd*** for core data types.
+***pwn.xsd*** for PWN namespace.
+***ili.xsd*** for ili namespace.
+***meta.xsd*** for meta namespace.
+***core-2.0.xsd*** for elements and the core structure.
+
+This allows for different levels of validation to be performed. 
+
+This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next.For example the data that satisfies EWN-LMF-2.0.xsd is a subset of data validated by WN-LMF-2.0.xsd (or  WN-LMF-2.0 is a superset of EWN-LMF-2.0). 
+
+Another use is different IDREF validation depending on whether you are attempting at validating merged files or not.
+
+####id types
+
+idtypes-2.0.xsd and ewn-idtypes-2.0.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.
+
+####relaxed id types vs strict
+
+This deals with **id reference** validation.
+
+*(ewn-)idtypes-2.0.xsd* and *(ewn-)idtypes-2.0-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.
+
+####some resulting combinations:
+
+WN-LMF-2.0-relax_idrefs.xsd
+WN-LMF-2.0.xsd
+EWN-LMF-2.0-relax_idrefs.xsd
+EWN-LMF-2.0.xsd
+
+####migration
+
+A migration tool (to2.0.xsl) is provided in the form of an XSLT 1.0 transform. It does not change the structure nor the data. Only attributes are transformed to satisfy the new naming and namespaces.
+
+####EWN compatibility with 2.0 schema
+
+The transformed lexicographer files satisfy both:
+
+- WN-LMF-2.0-relax_idrefs.xsd
+- EWN-LMF-2.0-relax_idrefs.xsd
+
+The transformed merged file satisfies both:
+
+- WN-LMF-2.0.xsd
+- EWN-LMF-2.0.xsd
+
+####Validation tool
+
+[Preferred validation tool](https://github.com/1313ou/ewn-validate2) (based on Saxon, fast and efficient) 
+[Basic validation tool](https://github.com/1313ou/ewn-validate) (based on standard validation tools that come with Java8, may be slow) 

--- a/2.0/WN-LMF-2.0-relax_idrefs.xsd
+++ b/2.0/WN-LMF-2.0-relax_idrefs.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='idtypes-relax_idrefs.xsd' />
+	<xsd:include schemaLocation='wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='core-2.0.xsd' />
+
+</xsd:schema>

--- a/2.0/WN-LMF-2.0.xsd
+++ b/2.0/WN-LMF-2.0.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='idtypes.xsd' />
+	<xsd:include schemaLocation='wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='core-2.0.xsd' />
+
+</xsd:schema>

--- a/2.0/core-2.0.xsd
+++ b/2.0/core-2.0.xsd
@@ -147,9 +147,7 @@
 	<xsd:element name='SyntacticBehaviour'>
 		<xsd:complexType>
 			<xsd:attribute name='subcategorizationFrame' type='xsd:string' use='required' />
-			<xsd:attribute name='senses' type='SenseIDREFSType' use='optional' />
-			<!-- FAILS -->
-			<!-- <xsd:attribute name='senses' type='LocalSenseIDREFSType' use='optional' /> -->
+			<xsd:attribute name='senses' type='LocalSenseIDREFSType' use='optional' />
 		</xsd:complexType>
 	</xsd:element>
 

--- a/2.0/core-2.0.xsd
+++ b/2.0/core-2.0.xsd
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	xmlns:pwn='http://www.princeton.edu/wordnet/'
+	xmlns:ili='http://ili.org/ili/'
+	xmlns:meta='https://github.com/globalwordnet/schemas/meta/'
+	>
+
+	<xsd:import namespace='http://www.princeton.edu/wordnet/' 				schemaLocation='pwn.xsd' />
+	<xsd:import namespace='http://ili.org/ili/'								schemaLocation='ili.xsd' />
+	<xsd:import namespace='https://github.com/globalwordnet/schemas/meta/'	schemaLocation='meta.xsd' />
+
+	<!-- E L E M E N T S -->
+
+	<xsd:element name='LexicalResource'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Lexicon' maxOccurs='unbounded' />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Lexicon'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='LexicalEntry' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Synset' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='xsd:ID' use='required' />
+			<xsd:attribute name='label' type='xsd:string' use='required' />
+			<xsd:attribute name='language' type='xsd:string' use='required' />
+			<xsd:attribute name='email' type='xsd:string' use='required' />
+			<xsd:attribute name='license' type='xsd:string' use='required' />
+			<xsd:attribute name='version' type='xsd:string' use='required' />
+			<xsd:attribute name='url' type='xsd:string' use='optional' />
+			<xsd:attribute name='citation' type='xsd:string' use='optional' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='LexicalEntry'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Lemma' minOccurs='1' maxOccurs='1' />
+				<xsd:element ref='Form' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Sense' minOccurs='1' maxOccurs='unbounded' />
+				<xsd:element ref='SyntacticBehaviour' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='LexicalEntryIDType' use='required' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Lemma'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Tag' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='writtenForm' type='WrittenFormType' use='required' />
+			<xsd:attribute name='script' type='ScriptType' use='optional' />
+			<xsd:attribute name='partOfSpeech' type='PartOfSpeechType' use='required' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Form'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Tag' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='writtenForm' type='WrittenFormType' use='required' />
+			<xsd:attribute name='script' type='ScriptType' use='optional' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Sense'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='SenseRelation' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Example' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Count' minOccurs='0' maxOccurs='1' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='SenseIDType' use='required' />
+			<xsd:attribute name='synset' type='LocalSynsetIDREFType' use='required' />
+			<xsd:attribute name='n' type='NType' use='optional' />
+			<xsd:attribute name='lexicalized' type='xsd:boolean' default='true' use='optional' />
+			<xsd:attribute ref='pwn:sensekey' use='optional' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Synset'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Definition' minOccurs='0' maxOccurs='1' />
+				<xsd:element ref='ili:Definition' minOccurs='0' maxOccurs='1' />
+				<xsd:element ref='SynsetRelation' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Example' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='SynsetIDType' use='required' />
+			<xsd:attribute ref='ili:id' use='required' />
+			<xsd:attribute name='partOfSpeech' use='optional' type='PartOfSpeechType' />
+			<xsd:attribute name='lexfile' use='optional' type='LexFileType' />
+			<xsd:attribute name='lexicalized' type='xsd:boolean' default='true' use='optional' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Definition'>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='language' type='xsd:string' use='optional' />
+			<xsd:attribute name='sourceSense' type='SynsetIDREFType' use='optional' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Example'>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='language' type='xsd:string' use='optional' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='SynsetRelation'>
+		<xsd:complexType>
+			<xsd:attribute name='target' type='SynsetIDREFType' use='required' />
+			<xsd:attribute name='relType' type='SynsetRelationType' use='required' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='SenseRelation'>
+		<xsd:complexType>
+			<xsd:attribute name='target' type='SenseIDREFType' use='required' />
+			<xsd:attribute name='relType' type='SenseRelationType' use='required' />
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='SyntacticBehaviour'>
+		<xsd:complexType>
+			<xsd:attribute name='subcategorizationFrame' type='xsd:string' use='required' />
+			<xsd:attribute name='senses' type='SenseIDREFSType' use='optional' />
+			<!-- FAILS -->
+			<!-- <xsd:attribute name='senses' type='LocalSenseIDREFSType' use='optional' /> -->
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Tag'>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='category' type='xsd:string' use='required' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Count'>
+		<xsd:complexType mixed='true'>
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/2.0/ewn-idtypes-relax_idrefs.xsd
+++ b/2.0/ewn-idtypes-relax_idrefs.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid "ewn\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid "ewn\-\d{8}\-[nvars]">
+<!ENTITY senseid "ewn\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/2.0/ewn-idtypes.xsd
+++ b/2.0/ewn-idtypes.xsd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid "ewn\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid "ewn\-\d{8}\-[nvars]">
+<!ENTITY senseid "ewn\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/2.0/ewn-wordtypes.xsd
+++ b/2.0/ewn-wordtypes.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY word    "[a-zA-Z0-9 \-\.,!/':]+">
+]>
+
+<!-- ' ': of age -->
+<!-- '-': tete-a-tete -->
+<!-- '.': O.K. -->
+<!-- ' ': Prince William, Duke of Cumberland --><!-- HAPAX --> 
+<!-- '!': Yahoo! -->
+<!-- ':': Capital: Critique of Political Economy --><!-- HAPAX -->
+<!-- '/': A/C -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- form types -->
+
+	<xsd:simpleType name='WrittenFormType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='ScriptType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/2.0/idtypes-relax_idrefs.xsd
+++ b/2.0/idtypes-relax_idrefs.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid ".*\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid ".*\-\d{8}\-[nvars]">
+<!ENTITY senseid ".*\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/2.0/idtypes.xsd
+++ b/2.0/idtypes.xsd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid ".*\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid ".*\-\d{8}\-[nvars]">
+<!ENTITY senseid ".*\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/2.0/ili.xsd
+++ b/2.0/ili.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY ili "i\d+|in">
+]>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' 
+	xmlns:meta='https://github.com/globalwordnet/schemas/meta/'
+	xmlns:ili='http://ili.org/ili/'
+	targetNamespace='http://ili.org/ili/'
+	>
+
+	<xsd:import namespace='https://github.com/globalwordnet/schemas/meta/'	schemaLocation='meta.xsd' />
+
+	<!-- T Y P E S  -->
+
+	<xsd:simpleType name='IDType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&ili;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- A T T R I B U T E S -->
+
+	<xsd:attribute name='id' type='ili:IDType' />
+
+	<!-- E L E M E N T S -->
+
+	<xsd:element name='Definition'>
+		<xsd:complexType mixed='true'>
+			<xsd:attributeGroup ref='meta:Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>
+
+
+

--- a/2.0/meta.xsd
+++ b/2.0/meta.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+]>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:meta='https://github.com/globalwordnet/schemas/meta/'
+	targetNamespace='https://github.com/globalwordnet/schemas/meta/'
+	>
+
+	<!-- T Y P E S  -->
+
+	<xsd:simpleType name='ConfidenceScoreType'>
+		<xsd:restriction base='xsd:float'>
+			<xsd:minInclusive value='0.0' />
+			<xsd:maxInclusive value='1.0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- A T T R I B U T E S -->
+
+	<xsd:attribute name='contributor' type='xsd:string' />
+	<xsd:attribute name='coverage' type='xsd:string' />
+	<xsd:attribute name='creator' type='xsd:string' />
+	<xsd:attribute name='date' type='xsd:string' />
+	<xsd:attribute name='description' type='xsd:string' />
+	<xsd:attribute name='format' type='xsd:string' />
+	<xsd:attribute name='publisher' type='xsd:string' />
+	<xsd:attribute name='relation' type='xsd:string' />
+	<xsd:attribute name='rights' type='xsd:string' />
+	<xsd:attribute name='source' type='xsd:string' />
+	<xsd:attribute name='title' type='xsd:string' />
+	<xsd:attribute name='type' type='xsd:string' />
+	<xsd:attribute name='status' type='xsd:string' />
+	<xsd:attribute name='note' type='xsd:string' />
+	<xsd:attribute name='confidenceScore' type='meta:ConfidenceScoreType' default='1.0' />
+
+	<!-- G R O U P S  -->
+
+	<xsd:attributeGroup name='Meta'>
+		<xsd:attribute ref='meta:contributor' use='optional' />
+		<xsd:attribute ref='meta:coverage' use='optional' />
+		<xsd:attribute ref='meta:creator' use='optional' />
+		<xsd:attribute ref='meta:date' use='optional' />
+		<xsd:attribute ref='meta:description' use='optional' />
+		<xsd:attribute ref='meta:format' use='optional' />
+		<xsd:attribute ref='meta:publisher' use='optional' />
+		<xsd:attribute ref='meta:relation' use='optional' />
+		<xsd:attribute ref='meta:rights' use='optional' />
+		<xsd:attribute ref='meta:source' use='optional' />
+		<xsd:attribute ref='meta:title' use='optional' />
+		<xsd:attribute ref='meta:type' use='optional' />
+		<xsd:attribute ref='meta:status' use='optional' />
+		<xsd:attribute ref='meta:note' use='optional' />
+		<xsd:attribute ref='meta:confidenceScore' use='optional' />
+	</xsd:attributeGroup>
+
+</xsd:schema>

--- a/2.0/pwn.xsd
+++ b/2.0/pwn.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lemma "[a-z0-9_'/\-\.]+">
+<!ENTITY lexsense "\d+:\d+:\d+:[a-z0-9_'/\-\.]*:\d*">
+]>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' 
+	xmlns:pwn='http://www.princeton.edu/wordnet/'
+	targetNamespace='http://www.princeton.edu/wordnet/'
+	>
+
+	<!-- T Y P E S  -->
+
+	<xsd:simpleType name='LegacySenseKeyType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&lemma;\%&lexsense;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- A T T R I B U T E S -->
+
+	<xsd:attribute name='sensekey' type='pwn:LegacySenseKeyType' />
+
+</xsd:schema>
+
+
+

--- a/2.0/to2.0.xsl
+++ b/2.0/to2.0.xsl
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+	xmlns:pwn="http://www.princeton.edu/wordnet/" 
+	xmlns:ili="http://ili.org/ili/"
+	xmlns:meta="https://github.com/globalwordnet/schemas/meta/" >
+
+	<!-- <xsl:output doctype-system="http://globalwordnet.github.io/schemas/WN-LMF-relaxed-2.0.dtd" method="xml" indent="no" /> -->
+	<xsl:output method="xml" indent="no" />
+
+	<xsl:variable name="debug" select="false()" />
+	<xsl:variable name="debug0" select="false()" />
+	<xsl:variable name="debug_ns" select="false()" />
+	<xsl:variable name="debug1" select="true()" />
+	<xsl:variable name="debug2" select="true()" />
+	<xsl:variable name="debug3" select="false()" />
+
+	<!-- in ns -->
+	<xsl:variable name="ns_dc" select="'http://purl.org/dc/elements/1.1/'" />
+
+	<!-- out ns -->
+	<xsl:variable name="ns_ili" select="'http://ili.org/ili/'" />
+	<xsl:variable name="ns_meta" select="'https://github.com/globalwordnet/schemas/meta/'" />
+	<xsl:variable name="ns_pwn" select="'http://www.princeton.edu/wordnet/'" />
+
+	<xsl:template match="LexicalResource">
+		<LexicalResource 
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			xsi:schemaLocation=". https://x-englishwordnet.github.io/schemas/2.0/xEWN-LMF-2.0-relax_idrefs.xsd" 
+			xmlns:pwn="http://www.princeton.edu/wordnet/" xmlns:ili="http://ili.org/ili/"
+			xmlns:meta="https://github.com/globalwordnet/schemas/meta/">
+			<xsl:apply-templates select="*" />
+		</LexicalResource>
+	</xsl:template>
+
+	<xsl:template match="ILIDefinition">
+		<xsl:element name="ili:Definition">
+			<xsl:apply-templates select="text()" />
+		</xsl:element>
+	</xsl:template>
+
+	<xsl:template match="*">
+
+		<xsl:if test="$debug">
+			<xsl:message>
+				<xsl:text>ele </xsl:text>
+				<xsl:value-of select="name()" />
+			</xsl:message>
+		</xsl:if>
+
+		<xsl:copy>
+
+			<!-- A T T R I B U T E S -->
+
+			<xsl:for-each select="@*">
+				<xsl:if test="$debug0">
+					<xsl:message>
+						<xsl:text>attr0 </xsl:text>
+						<xsl:value-of select="name()" />
+						<xsl:text> </xsl:text>
+						<xsl:value-of select="namespace-uri()" />
+					</xsl:message>
+				</xsl:if>
+
+				<xsl:choose>
+					<xsl:when test="namespace-uri() = $ns_dc">
+						<xsl:if test="$debug_ns">
+							<xsl:message>
+								<xsl:text>dc:attr </xsl:text>
+								<xsl:value-of select="name()" />
+							</xsl:message>
+						</xsl:if>
+
+						<xsl:choose>
+							<xsl:when test="local-name()='identifier'">
+								<xsl:attribute name="pwn:sensekey">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug1">
+									<xsl:message>
+										<xsl:text>dc:</xsl:text>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to pwn:sensekey</xsl:text>
+									</xsl:message>
+								</xsl:if>
+							</xsl:when>
+							<xsl:when test="local-name()='subject'">
+								<xsl:attribute name="lexfile">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug1">
+									<xsl:message>
+										<xsl:text>dc:</xsl:text>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to lexfile</xsl:text>
+									</xsl:message>
+								</xsl:if>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:attribute name="{concat('meta:',local-name())}">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug1">
+									<xsl:message>
+										<xsl:text>dc:</xsl:text>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to meta:</xsl:text>
+										<xsl:value-of select="local-name()" />
+									</xsl:message>
+								</xsl:if>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:when>
+
+					<xsl:when test="namespace-uri() != ''">
+						<xsl:message>
+							<xsl:text>not captured ns </xsl:text>
+							<xsl:value-of select="namespace-uri()" />
+						</xsl:message>
+					</xsl:when>
+
+					<xsl:otherwise>
+						<xsl:choose>
+							<xsl:when test="local-name()='ili'">
+								<xsl:attribute name="ili:id">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug2">
+									<xsl:message>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to ili:id</xsl:text>
+									</xsl:message>
+								</xsl:if>
+							</xsl:when>
+							<xsl:when test="local-name()='status'">
+								<xsl:attribute name="meta:status">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug2">
+									<xsl:message>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to meta:status</xsl:text>
+									</xsl:message>
+								</xsl:if>
+							</xsl:when>
+							<xsl:when test="local-name()='note'">
+								<xsl:attribute name="meta:note">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug2">
+									<xsl:message>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to meta:note</xsl:text>
+									</xsl:message>
+								</xsl:if>
+							</xsl:when>
+							<xsl:when test="local-name()='confidenceScore'">
+								<xsl:attribute name="meta:confidenceScore">
+									<xsl:value-of select="." />
+								</xsl:attribute>
+								<xsl:if test="$debug2">
+									<xsl:message>
+										<xsl:value-of select="local-name()" />
+										<xsl:text> to meta:confidenceScore</xsl:text>
+									</xsl:message>
+								</xsl:if>
+							</xsl:when>
+
+							<xsl:otherwise>
+								<xsl:copy>
+									<xsl:value-of select="." />
+								</xsl:copy>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:for-each>
+
+			<!-- S U B N O D E S -->
+
+			<xsl:for-each select="node()">
+				<xsl:apply-templates select="." />
+			</xsl:for-each>
+
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="@*">
+		<xsl:value-of select="." />
+	</xsl:template>
+
+	<xsl:template match="text()">
+		<xsl:if test="$debug3">
+			<xsl:message>
+				<xsl:text>text </xsl:text>
+				<xsl:value-of select="." />
+			</xsl:message>
+		</xsl:if>
+		<xsl:copy>
+			<xsl:value-of select="." />
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="comment()">
+		<xsl:if test="$debug3">
+			<xsl:message>
+				<xsl:text>comment </xsl:text>
+				<xsl:value-of select="." />
+			</xsl:message>
+		</xsl:if>
+		<xsl:copy>
+			<xsl:value-of select="." />
+		</xsl:copy>
+	</xsl:template>
+
+</xsl:transform>

--- a/2.0/types.xsd
+++ b/2.0/types.xsd
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+]>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- part-of-speech types -->
+
+	<xsd:simpleType name='PartOfSpeechType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='n' />
+			<xsd:enumeration value='v' />
+			<xsd:enumeration value='a' />
+			<xsd:enumeration value='r' />
+			<xsd:enumeration value='s' />
+			<xsd:enumeration value='t' />
+			<xsd:enumeration value='c' />
+			<xsd:enumeration value='p' />
+			<xsd:enumeration value='x' />
+			<xsd:enumeration value='u' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- relation types -->
+
+	<xsd:simpleType name='SynsetRelationType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='agent' />
+			<xsd:enumeration value='also' />
+			<xsd:enumeration value='antonym' />
+			<xsd:enumeration value='attribute' />
+			<xsd:enumeration value='be_in_state' />
+			<xsd:enumeration value='causes' />
+			<xsd:enumeration value='classified_by' />
+			<xsd:enumeration value='classifies' />
+			<xsd:enumeration value='co_agent_instrument' />
+			<xsd:enumeration value='co_agent_patient' />
+			<xsd:enumeration value='co_agent_result' />
+			<xsd:enumeration value='co_instrument_agent' />
+			<xsd:enumeration value='co_instrument_patient' />
+			<xsd:enumeration value='co_instrument_result' />
+			<xsd:enumeration value='co_patient_agent' />
+			<xsd:enumeration value='co_patient_instrument' />
+			<xsd:enumeration value='co_result_agent' />
+			<xsd:enumeration value='co_result_instrument' />
+			<xsd:enumeration value='co_role' />
+			<xsd:enumeration value='direction' />
+			<xsd:enumeration value='domain_region' />
+			<xsd:enumeration value='domain_topic' />
+			<xsd:enumeration value='entails' />
+			<xsd:enumeration value='eq_synonym' />
+			<xsd:enumeration value='exemplifies' />
+			<xsd:enumeration value='has_domain_region' />
+			<xsd:enumeration value='has_domain_topic' />
+			<xsd:enumeration value='holo_location' />
+			<xsd:enumeration value='holo_member' />
+			<xsd:enumeration value='holonym' />
+			<xsd:enumeration value='holo_part' />
+			<xsd:enumeration value='holo_portion' />
+			<xsd:enumeration value='holo_substance' />
+			<xsd:enumeration value='hypernym' />
+			<xsd:enumeration value='hyponym' />
+			<xsd:enumeration value='in_manner' />
+			<xsd:enumeration value='instance_hypernym' />
+			<xsd:enumeration value='instance_hyponym' />
+			<xsd:enumeration value='instrument' />
+			<xsd:enumeration value='involved' />
+			<xsd:enumeration value='involved_agent' />
+			<xsd:enumeration value='involved_direction' />
+			<xsd:enumeration value='involved_instrument' />
+			<xsd:enumeration value='involved_location' />
+			<xsd:enumeration value='involved_patient' />
+			<xsd:enumeration value='involved_result' />
+			<xsd:enumeration value='involved_source_direction' />
+			<xsd:enumeration value='involved_target_direction' />
+			<xsd:enumeration value='is_caused_by' />
+			<xsd:enumeration value='is_entailed_by' />
+			<xsd:enumeration value='is_exemplified_by' />
+			<xsd:enumeration value='is_subevent_of' />
+			<xsd:enumeration value='location' />
+			<xsd:enumeration value='manner_of' />
+			<xsd:enumeration value='mero_location' />
+			<xsd:enumeration value='mero_member' />
+			<xsd:enumeration value='meronym' />
+			<xsd:enumeration value='mero_part' />
+			<xsd:enumeration value='mero_portion' />
+			<xsd:enumeration value='mero_substance' />
+			<xsd:enumeration value='patient' />
+			<xsd:enumeration value='restricted_by' />
+			<xsd:enumeration value='restricts' />
+			<xsd:enumeration value='result' />
+			<xsd:enumeration value='role' />
+			<xsd:enumeration value='similar' />
+			<xsd:enumeration value='source_direction' />
+			<xsd:enumeration value='state_of' />
+			<xsd:enumeration value='subevent' />
+			<xsd:enumeration value='target_direction' />
+			<xsd:enumeration value='other' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='SenseRelationType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='antonym' />
+			<xsd:enumeration value='also' />
+			<xsd:enumeration value='participle' />
+			<xsd:enumeration value='pertainym' />
+			<xsd:enumeration value='derivation' />
+			<xsd:enumeration value='domain_topic' />
+			<xsd:enumeration value='has_domain_topic' />
+			<xsd:enumeration value='domain_region' />
+			<xsd:enumeration value='has_domain_region' />
+			<xsd:enumeration value='exemplifies' />
+			<xsd:enumeration value='is_exemplified_by' />
+			<xsd:enumeration value='similar' />
+			<xsd:enumeration value='other' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- lex file types -->
+
+	<xsd:simpleType name='LexFileType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='adj.all' />
+			<xsd:enumeration value='adj.pert' />
+			<xsd:enumeration value='adj.ppl' />
+			<xsd:enumeration value='adv.all' />
+			<xsd:enumeration value='noun.act' />
+			<xsd:enumeration value='noun.animal' />
+			<xsd:enumeration value='noun.artifact' />
+			<xsd:enumeration value='noun.attribute' />
+			<xsd:enumeration value='noun.body' />
+			<xsd:enumeration value='noun.cognition' />
+			<xsd:enumeration value='noun.communication' />
+			<xsd:enumeration value='noun.event' />
+			<xsd:enumeration value='noun.feeling' />
+			<xsd:enumeration value='noun.food' />
+			<xsd:enumeration value='noun.group' />
+			<xsd:enumeration value='noun.location' />
+			<xsd:enumeration value='noun.motive' />
+			<xsd:enumeration value='noun.object' />
+			<xsd:enumeration value='noun.person' />
+			<xsd:enumeration value='noun.phenomenon' />
+			<xsd:enumeration value='noun.plant' />
+			<xsd:enumeration value='noun.possession' />
+			<xsd:enumeration value='noun.process' />
+			<xsd:enumeration value='noun.quantity' />
+			<xsd:enumeration value='noun.relation' />
+			<xsd:enumeration value='noun.shape' />
+			<xsd:enumeration value='noun.state' />
+			<xsd:enumeration value='noun.substance' />
+			<xsd:enumeration value='noun.time' />
+			<xsd:enumeration value='noun.Tops' />
+			<xsd:enumeration value='verb.body' />
+			<xsd:enumeration value='verb.change' />
+			<xsd:enumeration value='verb.cognition' />
+			<xsd:enumeration value='verb.communication' />
+			<xsd:enumeration value='verb.competition' />
+			<xsd:enumeration value='verb.consumption' />
+			<xsd:enumeration value='verb.contact' />
+			<xsd:enumeration value='verb.creation' />
+			<xsd:enumeration value='verb.emotion' />
+			<xsd:enumeration value='verb.motion' />
+			<xsd:enumeration value='verb.perception' />
+			<xsd:enumeration value='verb.possession' />
+			<xsd:enumeration value='verb.social' />
+			<xsd:enumeration value='verb.stative' />
+			<xsd:enumeration value='verb.weather' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- index types -->
+
+	<xsd:simpleType name='NType'>
+		<xsd:restriction base='xsd:integer'>
+			<xsd:minInclusive value='0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- adj position type -->
+
+	<xsd:simpleType name='AdjPositionType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='a' />
+			<xsd:enumeration value='p' />
+			<xsd:enumeration value='ip' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- tag count type -->
+
+	<xsd:simpleType name='TagCntType'>
+		<xsd:restriction base='xsd:integer'>
+			<xsd:minInclusive value='0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/2.0/wordtypes.xsd
+++ b/2.0/wordtypes.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY word    ".+">
+]>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- form types -->
+
+	<xsd:simpleType name='WrittenFormType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='ScriptType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
### XSD Schema 2.0

(from README)

This is to equip WordNet with state-of-the-art validation schemas the way FrameNet did. This move is dictated by the following:

- DTD does not provide fine-grained control the way XSD does. The most significant difference between DTDs and XML Schema is the capability to create and use **datatypes**. XSD schemas define datatypes for elements and attributes while DTD doesn't support them. This allows for control on what sort of data (ids, content) is expected. Leveraging datatypes gets errors to bubble up instantly that would otherwise go unnoticed.

- It is desirable to distinguish foreign references from internal ones (more below).

- Incidentally the reference to  Dublin Core schema is erroneous (as mentioned [here](https://github.com/globalwordnet/schemas/issues/5) ) in that the definition of elements is mistakenly applied to attributes. Any real validation against the Dublin Core definitions would fail. Besides, Dublin Core seems superimposed and unnatural and it is doubtful it is of real use here.

####name spaces

References to ILI and PWN have been transferred to their own namespace (ili: and pwn: respectively) as do the meta annotations (meta:). 

It is not desirable to mix **foreign references** (in the sense that they refer to something outside the database, the PWN sensekey is a case in point) with **internal references**. Different namespaces reflect this.

####modules

 The design is modular:
 
***ili.xsd*** and ***pwn.xsd*** for all the ILI and PWN stuff in their own namespaces.
***(ewn-)idtypes(-relax_idrefs).xsd*** for core id types (it defines ID policy).
***(ewn-)wordtypes.xsd*** for word types (it defines word form policy).
***types.xsd*** for core data types.
***pwn.xsd*** for PWN namespace.
***ili.xsd*** for ili namespace.
***meta.xsd*** for meta namespace.
***core-2.0.xsd*** for elements and the core structure.

This allows for different levels of validation to be performed. 

This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next.For example the data that satisfies EWN-LMF-2.0.xsd is a subset of data validated by WN-LMF-2.0.xsd (or  WN-LMF-2.0 is a superset of EWN-LMF-2.0). 

Another use is different IDREF validation depending on whether you are attempting at validating merged files or not.

####id types

idtypes-2.0.xsd and ewn-idtypes-2.0.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.

####relaxed id types vs strict

This deals with **id reference** validation.

*(ewn-)idtypes-2.0.xsd* and *(ewn-)idtypes-2.0-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.

####some resulting combinations:

WN-LMF-2.0-relax_idrefs.xsd
WN-LMF-2.0.xsd
EWN-LMF-2.0-relax_idrefs.xsd
EWN-LMF-2.0.xsd

####migration

A migration tool (to2.0.xsl) is provided in the form of an XSLT 1.0 transform. It does not change the structure nor the data. Only attributes are transformed to satisfy the new naming and namespaces.

####EWN compatibility with 2.0 schema

The transformed lexicographer files satisfy both:

- WN-LMF-2.0-relax_idrefs.xsd
- EWN-LMF-2.0-relax_idrefs.xsd

The transformed merged file satisfies both:

- WN-LMF-2.0.xsd
- EWN-LMF-2.0.xsd

####Validation tool

[Preferred validation tool](https://github.com/1313ou/ewn-validate2) (based on Saxon, fast and efficient) 
[Basic validation tool](https://github.com/1313ou/ewn-validate) (based on standard validation tools that come with Java8, may be slow) 