### PR TITLE
1.10

### DIFF
--- a/1.10/README.md
+++ b/1.10/README.md
@@ -1,0 +1,69 @@
+#WordNet-LMF 1.10
+#===
+
+This is to equip WordNet with state-of-the-art validation schemas the way FrameNet did. This move is dictated by the following:
+
+- DTD does not provide fine-grained control the way XSD does. The most significant difference between DTDs and XML Schema is the capability to create and use **datatypes**. XSD schemas define datatypes for elements and attributes while DTD doesn't support them. This allows for control on what sort of data (ids, content) is expected. Leveraging datatypes gets errors to bubble up that would otherwise go unnoticed.
+
+- Incidentally the reference to  Dublin Core schema is erroneous (as mentioned [here](https://github.com/globalwordnet/schemas/issues/5) ) in that the definition of elements is mistakenly applied to attributes. Any real validation against the Dublin Core definitions would fail. Besides, Dublin Core seems superimposed and unnatural and it is doubtful it is of real use here.
+
+####name spaces
+
+Namespaces are left unchanged. Beyond the current namespace, the only namespace is dc:.
+
+####modules
+
+ The design is modular:
+ 
+***dc.xsd*** for dc: namespace.
+***(ewn-)idtypes(-relax_idrefs).xsd*** for id types (it defines ID policy).
+***(ewn-)idtypes-1.10(-relax_idrefs).xsd*** for id types (it defines ID policy).
+***(ewn-)wordtypes.xsd*** for id types (it defines ID policy).
+***types.xsd*** for core data types.
+***types-1.10.xsd*** for 1.10 data types.
+***pwn.xsd*** for PWN types.
+***ili.xsd*** for ili types.
+***meta.xsd*** for meta types.
+***core-1.10.xsd*** for elements and the core structure.
+
+This allows for different levels of validation to be performed. 
+
+This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next. For example the data that satisfies EWN-LMF-1.10.xsd is a subset of data validated by WN-LMF-1.10.xsd (or  WN-LMF-1.10 is a superset of EWN-LMF-1.10). 
+
+Another use is different IDREF validation depending on whether you are attempting at validating merged files or not.
+
+####id types
+
+idtypes-1.1.xsd and ewn-idtypes-1.10.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.
+
+####relaxed id types vs strict
+
+This deals with **id reference** validation.
+
+*(ewn-)idtypes-1.10.xsd* and *(ewn-)idtypes-1.10-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.
+
+####some resulting combinations:
+
+WN-LMF-1.10-relax_idrefs.xsd
+WN-LMF-1.10.xsd
+xEWN-LMF-1.10-relax_idrefs.xsd
+xEWN-LMF-1.10.xsd
+
+####xEWN compatibility with 1.10. schema
+
+xEWN stands for XSL transformed EWN and is to be found  [here](https://github.com/1313ou/english-wordnet) 
+
+The xsrc lexicographer files satisfy both:
+
+- WN-LMF-1.10-relax_idrefs.xsd
+- xEWN-LMF-1.10-relax_idrefs.xsd
+
+The xsrc merged file satisfies both:
+
+- WN-LMF-1.10.xsd
+- xEWN-LMF-1.10.xsd
+
+####Validation tool
+
+[Preferred validation tool](https://github.com/1313ou/ewn-validate2) (based on Saxon, fast and efficient) 
+[Basic validation tool](https://github.com/1313ou/ewn-validate) (based on standard validation tools that come with Java8, may be slow) 

--- a/1.10/README.md
+++ b/1.10/README.md
@@ -16,9 +16,9 @@ Namespaces are left unchanged. Beyond the current namespace, the only namespace 
  The design is modular:
  
 ***dc.xsd*** for dc: namespace.
-***(ewn-)idtypes(-relax_idrefs).xsd*** for id types (it defines ID policy).
+***(ewn-)idtypes(-relax_idrefs).xsd*** for core id types (it defines ID policy).
 ***(ewn-)idtypes-1.10(-relax_idrefs).xsd*** for id types (it defines ID policy).
-***(ewn-)wordtypes.xsd*** for id types (it defines ID policy).
+***(ewn-)wordtypes.xsd*** for word types (it defines word form policy).
 ***types.xsd*** for core data types.
 ***types-1.10.xsd*** for 1.10 data types.
 ***pwn.xsd*** for PWN types.
@@ -28,19 +28,19 @@ Namespaces are left unchanged. Beyond the current namespace, the only namespace 
 
 This allows for different levels of validation to be performed. 
 
-This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next. For example the data that satisfies EWN-LMF-1.10.xsd is a subset of data validated by WN-LMF-1.10.xsd (or  WN-LMF-1.10 is a superset of EWN-LMF-1.10). 
+This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next. For example the data that satisfies EWN-LMF-1.10.xsd is a subset of data validated by WN-LMF-1.10.xsd (or WN-LMF-1.10 is a superset of EWN-LMF-1.10). 
 
 Another use is different IDREF validation depending on whether you are attempting at validating merged files or not.
 
 ####id types
 
-idtypes-1.1.xsd and ewn-idtypes-1.10.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.
+idtypes.xsd and ewn-idtypes.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.
 
 ####relaxed id types vs strict
 
 This deals with **id reference** validation.
 
-*(ewn-)idtypes-1.10.xsd* and *(ewn-)idtypes-1.10-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.
+*(ewn-)idtypes.xsd* and *(ewn-)idtypes-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.
 
 ####some resulting combinations:
 

--- a/1.10/core-1.10.xsd
+++ b/1.10/core-1.10.xsd
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	xmlns:dc='http://purl.org/dc/elements/1.1/'
+	>
+
+	<xsd:import namespace='http://purl.org/dc/elements/1.1/'	schemaLocation='dc.xsd' />
+	<xsd:include												schemaLocation='pwn.xsd' />
+	<xsd:include												schemaLocation='ili.xsd' />
+	<xsd:include												schemaLocation='meta.xsd' />
+
+	<!-- E L E M E N T S -->
+
+	<xsd:element name='LexicalResource'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Lexicon' maxOccurs='unbounded' />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Lexicon'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='SyntacticBehaviour' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='LexicalEntry' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Synset' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='xsd:ID' use='required' />
+			<xsd:attribute name='label' type='xsd:string' use='required' />
+			<xsd:attribute name='language' type='xsd:string' use='required' />
+			<xsd:attribute name='email' type='xsd:string' use='required' />
+			<xsd:attribute name='license' type='xsd:string' use='required' />
+			<xsd:attribute name='version' type='xsd:string' use='required' />
+			<xsd:attribute name='url' type='xsd:string' use='optional' />
+			<xsd:attribute name='citation' type='xsd:string' use='optional' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='LexicalEntry'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Lemma' minOccurs='1' maxOccurs='1' />
+				<xsd:element ref='Form' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Sense' minOccurs='1' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='LexicalEntryIDType' use='required' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Lemma'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Tag' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='writtenForm' type='WrittenFormType' use='required' />
+			<xsd:attribute name='script' type='ScriptType' use='optional' />
+			<xsd:attribute name='partOfSpeech' type='PartOfSpeechType' use='required' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Form'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Tag' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='writtenForm' type='WrittenFormType' use='required' />
+			<xsd:attribute name='script' type='ScriptType' use='optional' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Sense'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='SenseRelation' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Example' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Count' minOccurs='0' maxOccurs='1' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='SenseIDType' use='required' />
+			<xsd:attribute name='synset' type='LocalSynsetIDREFType' use='required' />
+			<xsd:attribute name='n' type='NType' use='required' />
+			<xsd:attribute name='senseidx' type='SenseIdxType' use='required' />
+			<xsd:attribute name='lexfile' type='LexFileType' use='optional' />
+			<xsd:attribute name='lexid' type='LexIdType' use='required' />
+			<xsd:attribute name='sensekey' type='SensekeyType' use='required' />
+			<xsd:attribute name='verbFrames' type='LocalSyntacticBehaviourIDREFSType' use='optional' />
+			<xsd:attribute name='verbTemplates' type='LocalSyntacticBehaviourIDREFSType' use='optional' />
+			<xsd:attribute name='adjPosition' type='AdjPositionType' use='optional' />
+			<xsd:attribute name='tagCnt' type='TagCntType' default='0' use='optional' />
+			<xsd:attribute name='lexicalized' type='xsd:boolean' default='true' use='optional' />
+			<xsd:attribute ref='dc:identifier' use='optional' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Synset'>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref='Definition' minOccurs='0' maxOccurs='1' />
+				<xsd:element ref='ILIDefinition' minOccurs='0' maxOccurs='1' />
+				<xsd:element ref='SynsetRelation' minOccurs='0' maxOccurs='unbounded' />
+				<xsd:element ref='Example' minOccurs='0' maxOccurs='unbounded' />
+			</xsd:sequence>
+
+			<xsd:attribute name='id' type='SynsetIDType' use='required' />
+			<xsd:attribute ref='ili' use='required' />
+			<xsd:attribute name='partOfSpeech' use='optional' type='PartOfSpeechType' />
+			<xsd:attribute ref='dc:subject' use='optional' />
+			<xsd:attribute name='lexicalized' type='xsd:boolean' default='true' use='optional' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Definition'>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='language' type='xsd:string' use='optional' />
+			<xsd:attribute name='sourceSense' type='SynsetIDREFType' use='optional' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Example'>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='language' type='xsd:string' use='optional' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='SynsetRelation'>
+		<xsd:complexType>
+			<xsd:attribute name='target' type='SynsetIDREFType' use='required' />
+			<xsd:attribute name='relType' type='SynsetRelationType' use='required' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='SenseRelation'>
+		<xsd:complexType>
+			<xsd:attribute name='target' type='SenseIDREFType' use='required' />
+			<xsd:attribute name='relType' type='SenseRelationType' use='required' />
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='SyntacticBehaviour'>
+		<xsd:complexType>
+			<xsd:attribute name='id' type='SyntacticBehaviourIDType' use='required' />
+			<xsd:attribute name='subcategorizationFrame' type='xsd:string' use='optional' />
+			<xsd:attribute name='sentenceTemplate' type='xsd:string' use='optional' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Tag'>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='category' type='xsd:string' use='required' />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name='Count'>
+		<xsd:complexType mixed='true'>
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/1.10/dc.xsd
+++ b/1.10/dc.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+]>
+
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' 
+	xmlns:dc='http://purl.org/dc/elements/1.1/'
+	targetNamespace='http://purl.org/dc/elements/1.1/'>
+
+	<xsd:import schemaLocation='pwn.xsd' />
+	<xsd:import schemaLocation='types.xsd' />
+
+	<!-- A T T R I B U T E S -->
+
+	<!-- meta -->
+	<xsd:attribute name='contributor' type='xsd:string' />
+	<xsd:attribute name='coverage' type='xsd:string' />
+	<xsd:attribute name='creator' type='xsd:string' />
+	<xsd:attribute name='date' type='xsd:string' />
+	<xsd:attribute name='description' type='xsd:string' />
+	<xsd:attribute name='format' type='xsd:string' />
+	<xsd:attribute name='publisher' type='xsd:string' />
+	<xsd:attribute name='relation' type='xsd:string' />
+	<xsd:attribute name='rights' type='xsd:string' />
+	<xsd:attribute name='source' type='xsd:string' />
+	<xsd:attribute name='title' type='xsd:string' />
+	<xsd:attribute name='type' type='xsd:string' />
+
+	<!-- sensekey -->
+	<xsd:attribute name='identifier' type='LegacySenseKeyType' />
+
+	<!-- subject -->
+	<xsd:attribute name='subject' type='LexFileType' />
+
+</xsd:schema>
+
+
+

--- a/1.10/ewn-idtypes-1.10-relax_idrefs.xsd
+++ b/1.10/ewn-idtypes-1.10-relax_idrefs.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY syntacticbehaviourid "ewn\-s(b|t)\-\d{1,3}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- syntacticbehaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- syntactic behaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- syntactic behaviours -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/ewn-idtypes-1.10.xsd
+++ b/1.10/ewn-idtypes-1.10.xsd
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY syntacticbehaviourid "ewn\-s(b|t)\-\d{1,3}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- syntacticbehaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- syntactic behaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- syntactic behaviours -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/ewn-idtypes-relax_idrefs.xsd
+++ b/1.10/ewn-idtypes-relax_idrefs.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid "ewn\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid "ewn\-\d{8}\-[nvars]">
+<!ENTITY senseid "ewn\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/ewn-idtypes.xsd
+++ b/1.10/ewn-idtypes.xsd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid "ewn\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid "ewn\-\d{8}\-[nvars]">
+<!ENTITY senseid "ewn\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/ewn-wordtypes.xsd
+++ b/1.10/ewn-wordtypes.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY word    "[a-zA-Z0-9 \-\.,!/':]+">
+]>
+
+<!-- ' ': of age -->
+<!-- '-': tete-a-tete -->
+<!-- '.': O.K. -->
+<!-- ' ': Prince William, Duke of Cumberland --><!-- HAPAX --> 
+<!-- '!': Yahoo! -->
+<!-- ':': Capital: Critique of Political Economy --><!-- HAPAX -->
+<!-- '/': A/C -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- form types -->
+
+	<xsd:simpleType name='WrittenFormType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='ScriptType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/idtypes-1.10-relax_idrefs.xsd
+++ b/1.10/idtypes-1.10-relax_idrefs.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY syntacticbehaviourid ".*\-s(b|t)\-\d{1,3}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- syntacticbehaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- syntactic behaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- syntactic behaviours -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/idtypes-1.10.xsd
+++ b/1.10/idtypes-1.10.xsd
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY syntacticbehaviourid ".*\-s(b|t)\-\d{1,3}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- syntacticbehaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- syntactic behaviour -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&syntacticbehaviourid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- syntactic behaviours -->
+
+	<xsd:simpleType name='SyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSyntacticBehaviourIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&syntacticbehaviourid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/idtypes-relax_idrefs.xsd
+++ b/1.10/idtypes-relax_idrefs.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid ".*\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid ".*\-\d{8}\-[nvars]">
+<!ENTITY senseid ".*\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<!-- relax 'xsd:IDREF' -->
+		<xsd:restriction base='xsd:NCName'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<!-- relax 'xsd:IDREF' -->
+						<xsd:restriction base='xsd:NCName'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/idtypes.xsd
+++ b/1.10/idtypes.xsd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lexentryid ".*\-[a-zA-Z0-9_\.\-]*-[nvars]">
+<!ENTITY synsetid ".*\-\d{8}\-[nvars]">
+<!ENTITY senseid ".*\-.*\-[nvars]\-\d{8}\-\d{2}">
+]>
+<xsd:schema	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<!-- The LocalXXX variety means the target resides in the same file -->
+	<!-- The XXX variety means the target may reside in the same file or outside -->
+
+	<!-- I D -->
+
+	<!-- lexical entry -->
+
+	<xsd:simpleType name='LexicalEntryIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&lexentryid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDType'>
+		<xsd:restriction base='xsd:ID'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- I D R E F -->
+
+	<!-- synset -->
+
+	<xsd:simpleType name='SynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&synsetid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- synsets -->
+
+	<xsd:simpleType name='SynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSynsetIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&synsetid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sense -->
+
+	<xsd:simpleType name='SenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFType'>
+		<xsd:restriction base='xsd:IDREF'>
+			<xsd:pattern value='&senseid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- senses -->
+
+	<xsd:simpleType name='SenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='LocalSenseIDREFSType'>
+		<xsd:restriction>
+			<xsd:simpleType>
+				<xsd:list>
+					<xsd:simpleType>
+						<xsd:restriction base='xsd:IDREF'>
+							<xsd:pattern value='&senseid;' />
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:list>
+			</xsd:simpleType>
+			<xsd:minLength value='1' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/ili.xsd
+++ b/1.10/ili.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY ili "i\d+|in">
+]>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' 
+	>
+
+	<xsd:include schemaLocation='meta.xsd' />
+
+	<!-- T Y P E S  -->
+
+	<xsd:simpleType name='ILIIDType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&ili;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- A T T R I B U T E S -->
+
+	<xsd:attribute name='ili' type='ILIIDType' />
+
+	<!-- E L E M E N T S -->
+
+	<xsd:element name='ILIDefinition'>
+		<xsd:complexType mixed='true'>
+			<xsd:attributeGroup ref='Meta' />
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>
+
+
+

--- a/1.10/meta.xsd
+++ b/1.10/meta.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+]>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:dc='http://purl.org/dc/elements/1.1/'
+	>
+
+	<xsd:import namespace='http://purl.org/dc/elements/1.1/'	schemaLocation='dc.xsd' />
+
+	<!-- T Y P E S  -->
+
+	<xsd:simpleType name='ConfidenceScoreType'>
+		<xsd:restriction base='xsd:float'>
+			<xsd:minInclusive value='0.0' />
+			<xsd:maxInclusive value='1.0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- A T T R I B U T E S -->
+
+	<xsd:attribute name='status' type='xsd:string' />
+	<xsd:attribute name='note' type='xsd:string' />
+	<xsd:attribute name='confidenceScore' type='ConfidenceScoreType' default='1.0' />
+
+	<!-- G R O U P S  -->
+
+	<xsd:attributeGroup name='Meta'>
+		<xsd:attribute ref='dc:contributor' use='optional' />
+		<xsd:attribute ref='dc:coverage' use='optional' />
+		<xsd:attribute ref='dc:creator' use='optional' />
+		<xsd:attribute ref='dc:date' use='optional' />
+		<xsd:attribute ref='dc:description' use='optional' />
+		<xsd:attribute ref='dc:format' use='optional' />
+		<xsd:attribute ref='dc:publisher' use='optional' />
+		<xsd:attribute ref='dc:relation' use='optional' />
+		<xsd:attribute ref='dc:rights' use='optional' />
+		<xsd:attribute ref='dc:source' use='optional' />
+		<xsd:attribute ref='dc:title' use='optional' />
+		<xsd:attribute ref='dc:type' use='optional' />
+		<xsd:attribute ref='status' use='optional' />
+		<xsd:attribute ref='note' use='optional' />
+		<xsd:attribute ref='confidenceScore' use='optional' />
+	</xsd:attributeGroup>
+
+</xsd:schema>

--- a/1.10/pwn.xsd
+++ b/1.10/pwn.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY lemma "[a-z0-9_'/\-\.]+">
+<!ENTITY lexsense "\d+:\d+:\d+:[a-z0-9_'/\-\.]*:\d*">
+]>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' 
+	>
+
+	<!-- T Y P E S  -->
+
+	<xsd:simpleType name='LegacySenseKeyType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&lemma;\%&lexsense;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>
+
+
+

--- a/1.10/types-1.10.xsd
+++ b/1.10/types-1.10.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY sklemma "[a-zA-Z0-9_\-\.,!/'#]+">
+<!ENTITY lexsense_sstype "\d">
+<!ENTITY lexsense_lexfile "\d\d">
+<!ENTITY lexsense_lexid "\d\d">
+<!ENTITY nullable_lemma "[a-zA-Z0-9_'/\-\.]*">
+<!ENTITY nullable_lexsense_lexid "(\d\d)?">
+]>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- lex types -->
+
+	<xsd:simpleType name='LexIdType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='\d+' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='SenseIdxType'>
+		<xsd:restriction base='xsd:integer'>
+			<xsd:minInclusive value='0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- sensekey type -->
+
+	<xsd:simpleType name='SensekeyType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&sklemma;\%&lexsense_sstype;:&lexsense_lexfile;:&lexsense_lexid;:&nullable_lemma;:&nullable_lexsense_lexid;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/types.xsd
+++ b/1.10/types.xsd
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+]>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- part-of-speech types -->
+
+	<xsd:simpleType name='PartOfSpeechType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='n' />
+			<xsd:enumeration value='v' />
+			<xsd:enumeration value='a' />
+			<xsd:enumeration value='r' />
+			<xsd:enumeration value='s' />
+			<xsd:enumeration value='t' />
+			<xsd:enumeration value='c' />
+			<xsd:enumeration value='p' />
+			<xsd:enumeration value='x' />
+			<xsd:enumeration value='u' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- relation types -->
+
+	<xsd:simpleType name='SynsetRelationType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='agent' />
+			<xsd:enumeration value='also' />
+			<xsd:enumeration value='antonym' />
+			<xsd:enumeration value='attribute' />
+			<xsd:enumeration value='be_in_state' />
+			<xsd:enumeration value='causes' />
+			<xsd:enumeration value='classified_by' />
+			<xsd:enumeration value='classifies' />
+			<xsd:enumeration value='co_agent_instrument' />
+			<xsd:enumeration value='co_agent_patient' />
+			<xsd:enumeration value='co_agent_result' />
+			<xsd:enumeration value='co_instrument_agent' />
+			<xsd:enumeration value='co_instrument_patient' />
+			<xsd:enumeration value='co_instrument_result' />
+			<xsd:enumeration value='co_patient_agent' />
+			<xsd:enumeration value='co_patient_instrument' />
+			<xsd:enumeration value='co_result_agent' />
+			<xsd:enumeration value='co_result_instrument' />
+			<xsd:enumeration value='co_role' />
+			<xsd:enumeration value='direction' />
+			<xsd:enumeration value='domain_region' />
+			<xsd:enumeration value='domain_topic' />
+			<xsd:enumeration value='entails' />
+			<xsd:enumeration value='eq_synonym' />
+			<xsd:enumeration value='exemplifies' />
+			<xsd:enumeration value='has_domain_region' />
+			<xsd:enumeration value='has_domain_topic' />
+			<xsd:enumeration value='holo_location' />
+			<xsd:enumeration value='holo_member' />
+			<xsd:enumeration value='holonym' />
+			<xsd:enumeration value='holo_part' />
+			<xsd:enumeration value='holo_portion' />
+			<xsd:enumeration value='holo_substance' />
+			<xsd:enumeration value='hypernym' />
+			<xsd:enumeration value='hyponym' />
+			<xsd:enumeration value='in_manner' />
+			<xsd:enumeration value='instance_hypernym' />
+			<xsd:enumeration value='instance_hyponym' />
+			<xsd:enumeration value='instrument' />
+			<xsd:enumeration value='involved' />
+			<xsd:enumeration value='involved_agent' />
+			<xsd:enumeration value='involved_direction' />
+			<xsd:enumeration value='involved_instrument' />
+			<xsd:enumeration value='involved_location' />
+			<xsd:enumeration value='involved_patient' />
+			<xsd:enumeration value='involved_result' />
+			<xsd:enumeration value='involved_source_direction' />
+			<xsd:enumeration value='involved_target_direction' />
+			<xsd:enumeration value='is_caused_by' />
+			<xsd:enumeration value='is_entailed_by' />
+			<xsd:enumeration value='is_exemplified_by' />
+			<xsd:enumeration value='is_subevent_of' />
+			<xsd:enumeration value='location' />
+			<xsd:enumeration value='manner_of' />
+			<xsd:enumeration value='mero_location' />
+			<xsd:enumeration value='mero_member' />
+			<xsd:enumeration value='meronym' />
+			<xsd:enumeration value='mero_part' />
+			<xsd:enumeration value='mero_portion' />
+			<xsd:enumeration value='mero_substance' />
+			<xsd:enumeration value='patient' />
+			<xsd:enumeration value='restricted_by' />
+			<xsd:enumeration value='restricts' />
+			<xsd:enumeration value='result' />
+			<xsd:enumeration value='role' />
+			<xsd:enumeration value='similar' />
+			<xsd:enumeration value='source_direction' />
+			<xsd:enumeration value='state_of' />
+			<xsd:enumeration value='subevent' />
+			<xsd:enumeration value='target_direction' />
+			<xsd:enumeration value='other' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='SenseRelationType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='antonym' />
+			<xsd:enumeration value='also' />
+			<xsd:enumeration value='participle' />
+			<xsd:enumeration value='pertainym' />
+			<xsd:enumeration value='derivation' />
+			<xsd:enumeration value='domain_topic' />
+			<xsd:enumeration value='has_domain_topic' />
+			<xsd:enumeration value='domain_region' />
+			<xsd:enumeration value='has_domain_region' />
+			<xsd:enumeration value='exemplifies' />
+			<xsd:enumeration value='is_exemplified_by' />
+			<xsd:enumeration value='similar' />
+			<xsd:enumeration value='other' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- lex file types -->
+
+	<xsd:simpleType name='LexFileType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='adj.all' />
+			<xsd:enumeration value='adj.pert' />
+			<xsd:enumeration value='adj.ppl' />
+			<xsd:enumeration value='adv.all' />
+			<xsd:enumeration value='noun.act' />
+			<xsd:enumeration value='noun.animal' />
+			<xsd:enumeration value='noun.artifact' />
+			<xsd:enumeration value='noun.attribute' />
+			<xsd:enumeration value='noun.body' />
+			<xsd:enumeration value='noun.cognition' />
+			<xsd:enumeration value='noun.communication' />
+			<xsd:enumeration value='noun.event' />
+			<xsd:enumeration value='noun.feeling' />
+			<xsd:enumeration value='noun.food' />
+			<xsd:enumeration value='noun.group' />
+			<xsd:enumeration value='noun.location' />
+			<xsd:enumeration value='noun.motive' />
+			<xsd:enumeration value='noun.object' />
+			<xsd:enumeration value='noun.person' />
+			<xsd:enumeration value='noun.phenomenon' />
+			<xsd:enumeration value='noun.plant' />
+			<xsd:enumeration value='noun.possession' />
+			<xsd:enumeration value='noun.process' />
+			<xsd:enumeration value='noun.quantity' />
+			<xsd:enumeration value='noun.relation' />
+			<xsd:enumeration value='noun.shape' />
+			<xsd:enumeration value='noun.state' />
+			<xsd:enumeration value='noun.substance' />
+			<xsd:enumeration value='noun.time' />
+			<xsd:enumeration value='noun.Tops' />
+			<xsd:enumeration value='verb.body' />
+			<xsd:enumeration value='verb.change' />
+			<xsd:enumeration value='verb.cognition' />
+			<xsd:enumeration value='verb.communication' />
+			<xsd:enumeration value='verb.competition' />
+			<xsd:enumeration value='verb.consumption' />
+			<xsd:enumeration value='verb.contact' />
+			<xsd:enumeration value='verb.creation' />
+			<xsd:enumeration value='verb.emotion' />
+			<xsd:enumeration value='verb.motion' />
+			<xsd:enumeration value='verb.perception' />
+			<xsd:enumeration value='verb.possession' />
+			<xsd:enumeration value='verb.social' />
+			<xsd:enumeration value='verb.stative' />
+			<xsd:enumeration value='verb.weather' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- index types -->
+
+	<xsd:simpleType name='NType'>
+		<xsd:restriction base='xsd:integer'>
+			<xsd:minInclusive value='0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- adj position type -->
+
+	<xsd:simpleType name='AdjPositionType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:enumeration value='a' />
+			<xsd:enumeration value='p' />
+			<xsd:enumeration value='ip' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<!-- tag count type -->
+
+	<xsd:simpleType name='TagCntType'>
+		<xsd:restriction base='xsd:integer'>
+			<xsd:minInclusive value='0' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/wordtypes.xsd
+++ b/1.10/wordtypes.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<!DOCTYPE xsd:schema
+[
+<!ENTITY word    ".+">
+]>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	>
+
+	<!-- form types -->
+
+	<xsd:simpleType name='WrittenFormType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name='ScriptType'>
+		<xsd:restriction base='xsd:string'>
+			<xsd:pattern value='&word;' />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/1.10/xEWN-LMF-1.10-relax_idrefs.xsd
+++ b/1.10/xEWN-LMF-1.10-relax_idrefs.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='ewn-idtypes-relax_idrefs.xsd' />
+	<xsd:include schemaLocation='ewn-idtypes-1.10-relax_idrefs.xsd' />
+	<xsd:include schemaLocation='ewn-wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='types-1.10.xsd' />
+	<xsd:include schemaLocation='core-1.10.xsd' />
+
+</xsd:schema>

--- a/1.10/xEWN-LMF-1.10.xsd
+++ b/1.10/xEWN-LMF-1.10.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='ewn-idtypes.xsd' />
+	<xsd:include schemaLocation='ewn-idtypes-1.10.xsd' />
+	<xsd:include schemaLocation='ewn-wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='types-1.10.xsd' />
+	<xsd:include schemaLocation='core-1.10.xsd' />
+
+</xsd:schema>

--- a/1.10/xWN-LMF-1.10-relax_idrefs.xsd
+++ b/1.10/xWN-LMF-1.10-relax_idrefs.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='idtypes-relax_idrefs.xsd' />
+	<xsd:include schemaLocation='idtypes-1.10-relax_idrefs.xsd' />
+	<xsd:include schemaLocation='wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='types-1.10.xsd' />
+	<xsd:include schemaLocation='core-1.10.xsd' />
+
+</xsd:schema>

--- a/1.10/xWN-LMF-1.10.xsd
+++ b/1.10/xWN-LMF-1.10.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2020. Bernard Bou <1313ou@gmail.com>. -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+
+	<xsd:include schemaLocation='idtypes.xsd' />
+	<xsd:include schemaLocation='idtypes-1.10.xsd' />
+	<xsd:include schemaLocation='wordtypes.xsd' />
+	<xsd:include schemaLocation='types.xsd' />
+	<xsd:include schemaLocation='types-1.10.xsd' />
+	<xsd:include schemaLocation='core-1.10.xsd' />
+
+</xsd:schema>


### PR DESCRIPTION
### XSD Schema 1.10 

(from README)

This is to equip WordNet with state-of-the-art validation schemas the way FrameNet did. This move is dictated by the following:

- DTD does not provide fine-grained control the way XSD does. The most significant difference between DTDs and XML Schema is the capability to create and use **datatypes**. XSD schemas define datatypes for elements and attributes while DTD doesn't support them. This allows for control on what sort of data (ids, content) is expected. Leveraging datatypes gets errors to bubble up that would otherwise go unnoticed.

- Incidentally the reference to  Dublin Core schema is erroneous (as mentioned [here](https://github.com/globalwordnet/schemas/issues/5) ) in that the definition of elements is mistakenly applied to attributes. Any real validation against the Dublin Core definitions would fail. Besides, Dublin Core seems superimposed and unnatural and it is doubtful it is of real use here.

####name spaces

Namespaces are left unchanged. Beyond the current namespace, the only namespace is dc:.

####modules

 The design is modular:
 
***dc.xsd*** for dc: namespace.
***(ewn-)idtypes(-relax_idrefs).xsd*** for id types (it defines ID policy).
***(ewn-)idtypes-1.10(-relax_idrefs).xsd*** for id types (it defines ID policy).
***(ewn-)wordtypes.xsd*** for id types (it defines ID policy).
***types.xsd*** for core data types.
***types-1.10.xsd*** for 1.10 data types.
***pwn.xsd*** for PWN types.
***ili.xsd*** for ili types.
***meta.xsd*** for meta types.
***core-1.10.xsd*** for elements and the core structure.

This allows for different levels of validation to be performed. 

This makes it possible to bring stricter constraints to bear on the same data. But it does not mean the previous level is incompatible with the next. For example the data that satisfies EWN-LMF-1.10.xsd is a subset of data validated by WN-LMF-1.10.xsd (or  WN-LMF-1.10 is a superset of EWN-LMF-1.10). 

Another use is different IDREF validation depending on whether you are attempting at validating merged files or not.

####id types

idtypes-1.1.xsd and ewn-idtypes-1.10.xsd differ in that the latter imposes extra constraints on the **well-formedness** of EWN ids.

####relaxed id types vs strict

This deals with **id reference** validation.

*(ewn-)idtypes-1.10.xsd* and *(ewn-)idtypes-1.10-relax_idrefs.xsd* differ in that the latter allows some **non-local references not to have their target in the same file**. This is necessary in the case of part-of-speech cross-references such as the ones found in derivation relations (adj derived from noun, etc...) or maybe other cases (seealso, etc). The target then resides in a different file. This is useful to validate **pre-merging lexicographer files** while the strict mode must be used **to validate the merged file**, to make sure references are not left dangling.

####some resulting combinations:

WN-LMF-1.10-relax_idrefs.xsd
WN-LMF-1.10.xsd
xEWN-LMF-1.10-relax_idrefs.xsd
xEWN-LMF-1.10.xsd

####xEWN compatibility with 1.10. schema

xEWN stands for XSL transformed EWN and is to be found  [here](https://github.com/1313ou/english-wordnet) 

The xsrc lexicographer files satisfy both:

- WN-LMF-1.10-relax_idrefs.xsd
- xEWN-LMF-1.10-relax_idrefs.xsd

The xsrc merged file satisfies both:

- WN-LMF-1.10.xsd
- xEWN-LMF-1.10.xsd

####Validation tool

[Preferred validation tool](https://github.com/1313ou/ewn-validate2) (based on Saxon, fast and efficient) 
[Basic validation tool](https://github.com/1313ou/ewn-validate) (based on standard validation tools that come with Java8, may be slow) 