### PR TITLE
Post gwc

### DIFF
--- a/WN-LMF-1.1.dtd
+++ b/WN-LMF-1.1.dtd
@@ -57,6 +57,7 @@
     partOfSpeech (n|v|a|r|s|t|c|p|x|u) #REQUIRED>
 <!ELEMENT Form (Pronunciation*, Tag*)>
 <!ATTLIST Form
+    id ID #IMPLIED
     writtenForm CDATA #REQUIRED
     script CDATA #IMPLIED>
 <!ELEMENT Pronunciation (#PCDATA)>
@@ -280,8 +281,12 @@
     id ID #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
-<!ELEMENT ExternalLexicalEntry (Form*, (Sense|ExternalSense)*, SyntacticBehaviour*)>
+<!ELEMENT ExternalLexicalEntry (ExternalLemma?, (Form|ExternalForm)*, (Sense|ExternalSense)*, SyntacticBehaviour*)>
 <!ATTLIST ExternalLexicalEntry
+    id ID #REQUIRED>
+<!ELEMENT ExternalLemma (Pronunciation*, Tag*)>
+<!ELEMENT ExternalForm (Pronunciation*, Tag*)>
+<!ATTLIST ExternalForm
     id ID #REQUIRED>
 <!ELEMENT ExternalSense (SenseRelation*, Example*, Count*)>
 <!ATTLIST ExternalSense

--- a/WN-LMF-1.1.dtd
+++ b/WN-LMF-1.1.dtd
@@ -243,7 +243,7 @@
     status CDATA #IMPLIED
     note CDATA #IMPLIED
     confidenceScore CDATA #IMPLIED>
-<!ELEMENT LexiconExtension (Extends, Requires*, (LexicalEntry|ExternalLexicalEntry)*, (Synset|ExternalSynset)*)>
+<!ELEMENT LexiconExtension (Extends, Requires*, (LexicalEntry|ExternalLexicalEntry)*, (Synset|ExternalSynset)*, SyntacticBehaviour*)>
 <!ATTLIST LexiconExtension
     id ID #REQUIRED
     label CDATA #REQUIRED

--- a/WN-LMF-relaxed-1.1.dtd
+++ b/WN-LMF-relaxed-1.1.dtd
@@ -57,6 +57,7 @@
     partOfSpeech (n|v|a|r|s|t|c|p|x|u) #REQUIRED>
 <!ELEMENT Form (Pronunciation*, Tag*)>
 <!ATTLIST Form
+    id ID #IMPLIED
     writtenForm CDATA #REQUIRED
     script CDATA #IMPLIED>
 <!ELEMENT Pronunciation (#PCDATA)>
@@ -280,8 +281,12 @@
     id ID #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
-<!ELEMENT ExternalLexicalEntry (Form*, (Sense|ExternalSense)*, SyntacticBehaviour*)>
+<!ELEMENT ExternalLexicalEntry (ExternalLemma?, (Form|ExternalForm)*, (Sense|ExternalSense)*, SyntacticBehaviour*)>
 <!ATTLIST ExternalLexicalEntry
+    id ID #REQUIRED>
+<!ELEMENT ExternalLemma (Pronunciation*, Tag*)>
+<!ELEMENT ExternalForm (Pronunciation*, Tag*)>
+<!ATTLIST ExternalForm
     id ID #REQUIRED>
 <!ELEMENT ExternalSense (SenseRelation*, Example*, Count*)>
 <!ATTLIST ExternalSense

--- a/WN-LMF-relaxed-1.1.dtd
+++ b/WN-LMF-relaxed-1.1.dtd
@@ -243,7 +243,7 @@
     status CDATA #IMPLIED
     note CDATA #IMPLIED
     confidenceScore CDATA #IMPLIED>
-<!ELEMENT LexiconExtension (Extends, Requires*, (LexicalEntry|ExternalLexicalEntry)*, (Synset|ExternalSynset)*)>
+<!ELEMENT LexiconExtension (Extends, Requires*, (LexicalEntry|ExternalLexicalEntry)*, (Synset|ExternalSynset)*, SyntacticBehaviour*)>
 <!ATTLIST LexiconExtension
     id ID #REQUIRED
     label CDATA #REQUIRED


### PR DESCRIPTION
This adds some things as discussed in #23:

1. Adds `<SyntacticBehaviour>` as an element that can be added by `<LexiconExtension>` (in the LMF-1.1 position; it was already under `<ExternalLexicalEntry>`)
2. Adds an optional `id` attribute to `<Form>` elements
3. Adds `<ExternalForm>` and `<ExternalLemma>` elements as children of `<ExternalLexicalEntry>`

@jmccrae I also noticed that the new `id` attribute on `<SyntacticBehaviour>` was not ported to `WN-LMF-relaxed-1.1.dtd`. Is this intentional?