### PR TITLE
Add xml:space to WN-LMF-relaxed-1.3.dtd

### DIFF
--- a/WN-LMF-relaxed-1.3.dtd
+++ b/WN-LMF-relaxed-1.3.dtd
@@ -62,12 +62,14 @@
     script CDATA #IMPLIED>
 <!ELEMENT Pronunciation (#PCDATA)>
 <!ATTLIST Pronunciation
+    xml:space (default|preserve) "default"
     variety CDATA #IMPLIED
     notation CDATA #IMPLIED
     phonemic (true|false) "true"
     audio CDATA #IMPLIED>
 <!ELEMENT Tag (#PCDATA)>
 <!ATTLIST Tag
+    xml:space (default|preserve) "default"
     category CDATA #REQUIRED>
 <!ELEMENT Sense (SenseRelation*, Example*, Count*)>
 <!ATTLIST Sense
@@ -121,6 +123,7 @@
     lexfile CDATA #IMPLIED>
 <!ELEMENT Definition (#PCDATA)>
 <!ATTLIST Definition
+    xml:space (default|preserve) "default"
     language CDATA #IMPLIED
     sourceSense IDREF #IMPLIED
     dc:contributor CDATA #IMPLIED
@@ -142,6 +145,7 @@
     confidenceScore CDATA #IMPLIED>
 <!ELEMENT ILIDefinition (#PCDATA)>
 <!ATTLIST ILIDefinition
+    xml:space (default|preserve) "default"
     dc:contributor CDATA #IMPLIED
     dc:coverage CDATA #IMPLIED
     dc:creator CDATA #IMPLIED
@@ -161,6 +165,7 @@
     confidenceScore CDATA #IMPLIED>
 <!ELEMENT Example (#PCDATA)>
 <!ATTLIST Example
+    xml:space (default|preserve) "default"
     language CDATA #IMPLIED
     dc:contributor CDATA #IMPLIED
     dc:coverage CDATA #IMPLIED
@@ -228,6 +233,7 @@
   senses IDREFS #IMPLIED>
 <!ELEMENT Count (#PCDATA)>
 <!ATTLIST Count
+    xml:space (default|preserve) "default"
     dc:contributor CDATA #IMPLIED
     dc:coverage CDATA #IMPLIED
     dc:creator CDATA #IMPLIED


### PR DESCRIPTION
Fixes #77 by adding `xml:space` to some elements in `WN-LMF-relaxed-1.3.dtd` as they are in `WN-LMF-1.3.dtd`.