### PR TITLE
Change `id` property to `ref`

### DIFF
--- a/WN-LMF-1.4.dtd
+++ b/WN-LMF-1.4.dtd
@@ -281,12 +281,12 @@
     confidenceScore CDATA "1.0">
 <!ELEMENT Requires EMPTY>
 <!ATTLIST Requires
-    id ID #REQUIRED
+    ref ID #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT Extends EMPTY>
 <!ATTLIST Extends
-    id ID #REQUIRED
+    ref ID #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT ExternalLexicalEntry (ExternalLemma?, (Form|ExternalForm)*, (Sense|ExternalSense)*, SyntacticBehaviour*)>

--- a/WN-LMF-1.4.dtd
+++ b/WN-LMF-1.4.dtd
@@ -281,12 +281,12 @@
     confidenceScore CDATA "1.0">
 <!ELEMENT Requires EMPTY>
 <!ATTLIST Requires
-    ref ID #REQUIRED
+    ref CDATA #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT Extends EMPTY>
 <!ATTLIST Extends
-    ref ID #REQUIRED
+    ref CDATA #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT ExternalLexicalEntry (ExternalLemma?, (Form|ExternalForm)*, (Sense|ExternalSense)*, SyntacticBehaviour*)>

--- a/WN-LMF-relaxed-1.4.dtd
+++ b/WN-LMF-relaxed-1.4.dtd
@@ -275,12 +275,12 @@
     confidenceScore CDATA "1.0">
 <!ELEMENT Requires EMPTY>
 <!ATTLIST Requires
-    ref ID #REQUIRED
+    ref CDATA #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT Extends EMPTY>
 <!ATTLIST Extends
-    ref ID #REQUIRED
+    ref CDATA #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT ExternalLexicalEntry (ExternalLemma?, (Form|ExternalForm)*, (Sense|ExternalSense)*, SyntacticBehaviour*)>

--- a/WN-LMF-relaxed-1.4.dtd
+++ b/WN-LMF-relaxed-1.4.dtd
@@ -275,12 +275,12 @@
     confidenceScore CDATA "1.0">
 <!ELEMENT Requires EMPTY>
 <!ATTLIST Requires
-    id ID #REQUIRED
+    ref ID #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT Extends EMPTY>
 <!ATTLIST Extends
-    id ID #REQUIRED
+    ref ID #REQUIRED
     version CDATA #REQUIRED
     url CDATA #IMPLIED>
 <!ELEMENT ExternalLexicalEntry (ExternalLemma?, (Form|ExternalForm)*, (Sense|ExternalSense)*, SyntacticBehaviour*)>

--- a/index.md
+++ b/index.md
@@ -369,7 +369,7 @@ They are defined much like regular lexicons, but the `<Extends>` element specifi
                           email="goodmami@uw.edu"
                           license="https://creativecommons.org/publicdomain/zero/1.0/"
                           version="1.0">
-            <Extends id="ewn" version="2020" />
+            <Extends ref="ewn" version="2020" />
 
 The contents of the lexicon extension are the same as a regular lexicon with the addition of elements for external lexical entries, synsets, and senses.
 There are two uses of external elements.
@@ -409,7 +409,7 @@ With the `<Requires>` element, it is possible to explicitly codify those depende
                  dc:format="OMW-LMF"
                  dc:description="Wordnet made from OMW 1.0 data"
                  confidenceScore="1.0">
-	        <Requires id="pwn" version="3.0" />
+	        <Requires ref="pwn" version="3.0" />
 
 This element signifies to an application processing the wordnet that the required wordnet should be loaded as well.
 The `<Requires>` element may also be used on a `<LexiconExtension>` for cases where the lexicon extends one wordnet but requires another.


### PR DESCRIPTION
Fixes #94 

I am a little concerned about this PR as it is not backwards-compatible, which (I believe) is the first change we have made that is not simply additive. I think we may be okay to do this as it is not widely used but I would like some opinions from @goodmami  and @fcbond about how many resources use the `<Extends>` and `<Requires>` elements.